### PR TITLE
Improve tokenization with env vars

### DIFF
--- a/milestone_4/mini-shell/src/tokenizer.c
+++ b/milestone_4/mini-shell/src/tokenizer.c
@@ -1,5 +1,6 @@
 #include "../include/minishell.h"
 #include <ctype.h>
+#include <stddef.h>
 
 static t_token *new_token(t_token_type type, char *value)
 {
@@ -30,6 +31,102 @@ static char     *substr_dup(const char *s, size_t start, size_t len)
         return (ft_substr(s, start, len));
 }
 
+/* Simple strdup replacement */
+static char     *ms_strdup(const char *s)
+{
+    char    *dup;
+    size_t  i;
+
+    dup = (char *)malloc(ft_strlen(s) + 1);
+    if (!dup)
+        return (NULL);
+    i = 0;
+    while (s[i])
+    {
+        dup[i] = s[i];
+        i++;
+    }
+    dup[i] = '\0';
+    return (dup);
+}
+
+/* Join s1 and s2, free s1 */
+static char     *ms_strjoin_free(char *s1, const char *s2)
+{
+    size_t  len1;
+    size_t  len2;
+    char    *new;
+    size_t  i;
+
+    len1 = s1 ? ft_strlen(s1) : 0;
+    len2 = ft_strlen(s2);
+    new = (char *)malloc(len1 + len2 + 1);
+    if (!new)
+    {
+        free(s1);
+        return (NULL);
+    }
+    i = 0;
+    while (s1 && i < len1)
+    {
+        new[i] = s1[i];
+        i++;
+    }
+    for (size_t j = 0; j < len2; j++)
+        new[i++] = s2[j];
+    new[i] = '\0';
+    free(s1);
+    return (new);
+}
+
+static char     *expand_env_segment(const char *segment)
+{
+    char    *res;
+    size_t  i;
+
+    res = ms_strdup("");
+    if (!res)
+        return (NULL);
+    i = 0;
+    while (segment[i])
+    {
+        if (segment[i] == '$')
+        {
+            size_t  start;
+            char    *name;
+            char    *val;
+            char    *tmp;
+
+            i++;
+            start = i;
+            while (segment[i] && (isalnum((unsigned char)segment[i]) || segment[i] == '_'))
+                i++;
+            if (start == i)
+            {
+                res = ms_strjoin_free(res, "$");
+                continue;
+            }
+            name = substr_dup(segment, start, i - start);
+            val = getenv(name);
+            free(name);
+            if (!val)
+                val = "";
+            tmp = ms_strjoin_free(res, val);
+            res = tmp;
+        }
+        else
+        {
+            char ch[2];
+
+            ch[0] = segment[i];
+            ch[1] = '\0';
+            res = ms_strjoin_free(res, ch);
+            i++;
+        }
+    }
+    return (res);
+}
+
 static size_t   add_symbol(t_token **lst, t_token_type type,
                         const char *sym, size_t len)
 {
@@ -43,7 +140,9 @@ static size_t  read_word(const char *line, size_t i, char **out)
     while (line[i] && !isspace((unsigned char)line[i]) &&
            line[i] != '|' && line[i] != '<' && line[i] != '>')
         i++;
-    *out = substr_dup(line, start, i - start);
+    char *tmp = substr_dup(line, start, i - start);
+    *out = expand_env_segment(tmp);
+    free(tmp);
     return i;
 }
 
@@ -53,7 +152,12 @@ static size_t  read_quoted(const char *line, size_t i, char **out)
     size_t start = i;
     while (line[i] && line[i] != quote)
         i++;
-    *out = substr_dup(line, start, i - start);
+    char *tmp = substr_dup(line, start, i - start);
+    if (quote == '"')
+        *out = expand_env_segment(tmp);
+    else
+        *out = ms_strdup(tmp);
+    free(tmp);
     if (line[i] == quote)
         i++;
     return i;


### PR DESCRIPTION
## Summary
- add env var expansion helper functions
- expand variables in words and inside double quotes

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_686824712a488326a541b0b0014f98f0